### PR TITLE
rename startProcess to startProcessInstance

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/core_contracts": "^1.0.0",
     "@essential-projects/errors_ts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
-    "@process-engine/consumer_api_contracts": "feature~rename_start_process_to_net_specs",
+    "@process-engine/consumer_api_contracts": "^0.5.0",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/core_contracts": "^1.0.0",
     "@essential-projects/errors_ts": "^1.0.0",
     "@essential-projects/http_node": "^1.0.0",
-    "@process-engine/consumer_api_contracts": "^0.3.0",
+    "@process-engine/consumer_api_contracts": "feature~rename_start_process_to_net_specs",
     "addict-ioc": "^2.2.8",
     "async-middleware": "^1.2.1",
     "bluebird": "^3.4.7",

--- a/src/consumer_api_controller.ts
+++ b/src/consumer_api_controller.ts
@@ -8,7 +8,7 @@ import {
   ProcessModelList,
   ProcessStartRequestPayload,
   ProcessStartResponsePayload,
-  ProcessStartReturnOnOptions,
+  StartCallbackType,
   UserTaskList,
   UserTaskResult,
 } from '@process-engine/consumer_api_contracts';
@@ -61,16 +61,16 @@ export class ConsumerApiController {
     const processModelKey: string = request.params.process_model_key;
     const startEventKey: string = request.params.start_event_key;
     const payload: ProcessStartRequestPayload = request.body;
-    let returnOn: ProcessStartReturnOnOptions = request.query.return_on;
+    let startCallbackType: StartCallbackType = <StartCallbackType> Number.parseInt(request.query.start_callback_type);
 
-    if (!returnOn) {
-      returnOn = ProcessStartReturnOnOptions.onProcessInstanceStarted;
+    if (!startCallbackType) {
+      startCallbackType = StartCallbackType.CallbackOnProcessInstanceCreated;
     }
 
     const context: ConsumerContext = request.consumerContext;
 
     const result: ProcessStartResponsePayload =
-      await this.consumerApiService.startProcessInstance(context, processModelKey, startEventKey, payload, returnOn);
+      await this.consumerApiService.startProcessInstance(context, processModelKey, startEventKey, payload, startCallbackType);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/consumer_api_controller.ts
+++ b/src/consumer_api_controller.ts
@@ -57,7 +57,7 @@ export class ConsumerApiController {
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }
 
-  public async startProcess(request: ConsumerRequest, response: Response): Promise<void> {
+  public async startProcessInstance(request: ConsumerRequest, response: Response): Promise<void> {
     const processModelKey: string = request.params.process_model_key;
     const startEventKey: string = request.params.start_event_key;
     const payload: ProcessStartRequestPayload = request.body;
@@ -70,12 +70,12 @@ export class ConsumerApiController {
     const context: ConsumerContext = request.consumerContext;
 
     const result: ProcessStartResponsePayload =
-      await this.consumerApiService.startProcess(context, processModelKey, startEventKey, payload, returnOn);
+      await this.consumerApiService.startProcessInstance(context, processModelKey, startEventKey, payload, returnOn);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }
 
-  public async startProcessAndAwaitEndEvent(request: ConsumerRequest, response: Response): Promise<void> {
+  public async startProcessInstanceAndAwaitEndEvent(request: ConsumerRequest, response: Response): Promise<void> {
     const processModelKey: string = request.params.process_model_key;
     const startEventKey: string = request.params.start_event_key;
     const endEventKey: string = request.params.end_event_key;
@@ -83,7 +83,7 @@ export class ConsumerApiController {
     const context: ConsumerContext = request.consumerContext;
 
     const result: ProcessStartResponsePayload =
-      await this.consumerApiService.startProcessAndAwaitEndEvent(context, processModelKey, startEventKey, endEventKey, payload);
+      await this.consumerApiService.startProcessInstanceAndAwaitEndEvent(context, processModelKey, startEventKey, endEventKey, payload);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/consumer_api_router.ts
+++ b/src/consumer_api_router.ts
@@ -41,8 +41,8 @@ export class ConsumerApiRouter extends BaseRouter {
 
     this.router.get(restSettings.paths.processModels, wrap(controller.getProcessModels.bind(controller)));
     this.router.get(restSettings.paths.processModelByKey, wrap(controller.getProcessModelByKey.bind(controller)));
-    this.router.post(restSettings.paths.startProcess, wrap(controller.startProcess.bind(controller)));
-    this.router.post(restSettings.paths.startProcessAndAwaitEndEvent, wrap(controller.startProcessAndAwaitEndEvent.bind(controller)));
+    this.router.post(restSettings.paths.startProcess, wrap(controller.startProcessInstance.bind(controller)));
+    this.router.post(restSettings.paths.startProcessAndAwaitEndEvent, wrap(controller.startProcessInstanceAndAwaitEndEvent.bind(controller)));
   }
 
   private registerEventRoutes(): void {


### PR DESCRIPTION
## What did you change?

- Rename `startProcess` to `startProcessInstance`
- Rename `startProcessAndAwaitEndEvent` to `startProcessInstanceAndAwaitEndEvent`

The method signatures now match the .NET Consumer API definitions.

## How can others test the changes?

This is a cosmetic change, so everything should work as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
