### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -5,7 +5,7 @@ const {
   ConsumerApiController,
 } = require('./dist/commonjs/index');
 
-const routerDiscoveryTag = require('@essential-projects/core_contracts').RouterDiscoveryTag;
+const routerDiscoveryTag = require('@essential-projects/bootstrapper_contracts').routerDiscoveryTag;
 
 function registerInContainer(container) {
   container.register('ConsumerApiRouter', ConsumerApiRouter)

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -14,7 +14,7 @@ function registerInContainer(container) {
     .tags(routerDiscoveryTag);
 
   container.register('ConsumerApiController', ConsumerApiController)
-    .dependencies('ConsumerApiService', 'IamService')
+    .dependencies('ConsumerApiService')
     .singleton();
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_http",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "the http-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
+    "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
     "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/http_node": "^2.0.0",
     "@process-engine/consumer_api_contracts": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/process-engine/consumer_api#readme",
   "dependencies": {
-    "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
+    "@essential-projects/bootstrapper_contracts": "^1.0.0",
     "@essential-projects/errors_ts": "^1.1.0",
     "@essential-projects/http_node": "^2.0.0",
     "@process-engine/consumer_api_contracts": "^0.12.1",


### PR DESCRIPTION
## What did you change?

Get the discovery tags from the new `bootstrapper_contracts` package and remove a redundant reference to the iam service.

## How can others test the changes?

No functions have been touched, so all should run as before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
