### PR TITLE
✨ Get instances and tasks by identity

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -20,7 +20,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ConsumerApiSocketEndpoint', ConsumerApiSocketEndpoint)
-    .dependencies('EventAggregator')
+    .dependencies('ConsumerApiService', 'EventAggregator')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
     "@essential-projects/iam_contracts": "~3.3.0",
-    "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
+    "@process-engine/consumer_api_contracts": "~2.0.0",
     "async-middleware": "1.2.1",
     "jsonwebtoken": "~8.4.0",
     "loggerhythm": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
-    "@essential-projects/iam_contracts": "~3.2.0",
+    "@essential-projects/iam_contracts": "feature~get_instances_by_owner_id",
     "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
     "loggerhythm": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_http",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "the http-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
-    "@essential-projects/iam_contracts": "feature~get_instances_by_owner_id",
+    "@essential-projects/iam_contracts": "~3.3.0",
     "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
+    "jsonwebtoken": "~8.4.0",
     "loggerhythm": "3.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
     "@essential-projects/iam_contracts": "~3.2.0",
-    "@process-engine/consumer_api_contracts": "~1.3.0",
+    "@process-engine/consumer_api_contracts": "feature~get_instances_by_owner_id",
     "async-middleware": "1.2.1",
     "loggerhythm": "3.0.3"
   },

--- a/src/consumer_api_controller.ts
+++ b/src/consumer_api_controller.ts
@@ -8,6 +8,7 @@ import {
   IConsumerApi,
   IConsumerApiHttpController,
   ManualTaskList,
+  ProcessInstance,
   ProcessModel,
   ProcessModelList,
   ProcessStartRequestPayload,
@@ -73,6 +74,14 @@ export class ConsumerApiController implements IConsumerApiHttpController {
     const identity: IIdentity = request.identity;
 
     const result: Array<CorrelationResult> = await this.consumerApiService.getProcessResultForCorrelation(identity, correlationId, processModelId);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async getProcessInstancesByIdentity(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const identity: IIdentity = request.identity;
+
+    const result: Array<ProcessInstance> = await this.consumerApiService.getProcessInstancesByIdentity(identity);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }
@@ -151,6 +160,14 @@ export class ConsumerApiController implements IConsumerApiHttpController {
     const identity: IIdentity = request.identity;
 
     const result: UserTaskList = await this.consumerApiService.getUserTasksForProcessModelInCorrelation(identity, processModelId, correlationId);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async getWaitingUserTasksByIdentity(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const identity: IIdentity = request.identity;
+
+    const result: UserTaskList = await this.consumerApiService.getWaitingUserTasksByIdentity(identity);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/consumer_api_controller.ts
+++ b/src/consumer_api_controller.ts
@@ -213,6 +213,14 @@ export class ConsumerApiController implements IConsumerApiHttpController {
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }
 
+  public async getWaitingManualTasksByIdentity(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const identity: IIdentity = request.identity;
+
+    const result: ManualTaskList = await this.consumerApiService.getWaitingManualTasksByIdentity(identity);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
   public async finishManualTask(request: HttpRequestWithIdentity, response: Response): Promise<void> {
     const correlationId: string = request.params.correlation_id;
     const identity: IIdentity = request.identity;

--- a/src/consumer_api_controller.ts
+++ b/src/consumer_api_controller.ts
@@ -6,6 +6,7 @@ import {
   EventList,
   EventTriggerPayload,
   IConsumerApi,
+  IConsumerApiHttpController,
   ManualTaskList,
   ProcessModel,
   ProcessModelList,
@@ -18,7 +19,7 @@ import {
 
 import {Response} from 'express';
 
-export class ConsumerApiController {
+export class ConsumerApiController implements IConsumerApiHttpController {
   public config: any = undefined;
 
   private httpCodeSuccessfulResponse: number = 200;

--- a/src/consumer_api_router.ts
+++ b/src/consumer_api_router.ts
@@ -40,6 +40,7 @@ export class ConsumerApiRouter extends BaseRouter {
     this.router.get(restSettings.paths.processModels, wrap(controller.getProcessModels.bind(controller)));
     this.router.get(restSettings.paths.processModelById, wrap(controller.getProcessModelById.bind(controller)));
     this.router.get(restSettings.paths.getProcessResultForCorrelation, wrap(controller.getProcessResultForCorrelation.bind(controller)));
+    this.router.get(restSettings.paths.getOwnProcessInstances, wrap(controller.getProcessInstancesByIdentity.bind(controller)));
     this.router.post(restSettings.paths.startProcessInstance, wrap(controller.startProcessInstance.bind(controller)));
   }
 
@@ -59,6 +60,7 @@ export class ConsumerApiRouter extends BaseRouter {
     this.router.get(restSettings.paths.processModelUserTasks, wrap(controller.getUserTasksForProcessModel.bind(controller)));
     this.router.get(restSettings.paths.correlationUserTasks, wrap(controller.getUserTasksForCorrelation.bind(controller)));
     this.router.get(restSettings.paths.processModelCorrelationUserTasks, wrap(controller.getUserTasksForProcessModelInCorrelation.bind(controller)));
+    this.router.get(restSettings.paths.getOwnUserTasks, wrap(controller.getWaitingUserTasksByIdentity.bind(controller)));
     this.router.post(restSettings.paths.finishUserTask, wrap(controller.finishUserTask.bind(controller)));
   }
 

--- a/src/consumer_api_router.ts
+++ b/src/consumer_api_router.ts
@@ -71,6 +71,7 @@ export class ConsumerApiRouter extends BaseRouter {
     this.router.get(restSettings.paths.correlationManualTasks, wrap(controller.getManualTasksForCorrelation.bind(controller)));
     this.router.get(restSettings.paths.processModelCorrelationManualTasks,
        wrap(controller.getManualTasksForProcessModelInCorrelation.bind(controller)));
+    this.router.get(restSettings.paths.getOwnManualTasks, wrap(controller.getWaitingManualTasksByIdentity.bind(controller)));
     this.router.post(restSettings.paths.finishManualTask, wrap(controller.finishManualTask.bind(controller)));
   }
 }

--- a/src/consumer_api_socket_endpoint.ts
+++ b/src/consumer_api_socket_endpoint.ts
@@ -83,12 +83,12 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processEnded,
-      (processEndedMessage: Messages.SystemEvents.ProcessEndedMessage) => {
+      (processEndedMessage: Messages.BpmnEvents.EndEventReachedMessage) => {
         socketIo.emit(socketSettings.paths.processEnded, processEndedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processTerminated,
-      (processTerminatedMessage: Messages.SystemEvents.ProcessEndedMessage) => {
+      (processTerminatedMessage: Messages.BpmnEvents.TerminateEndEventReachedMessage) => {
         socketIo.emit(socketSettings.paths.processTerminated, processTerminatedMessage);
       });
   }

--- a/src/consumer_api_socket_endpoint.ts
+++ b/src/consumer_api_socket_endpoint.ts
@@ -67,7 +67,7 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
       // We can just pass on the received message, because the ConsumerApiService
       // will already have ensured that the identites match.
       this._consumerApiService.onUserTaskForIdentityWaiting(connection.identity,
-        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+        (message: Messages.Public.SystemEvents.UserTaskReachedMessage) => {
 
           const eventToPublish: string = socketSettings.paths.userTaskForIdentityWaiting
             .replace(socketSettings.pathParams.userId, connection.userId);
@@ -76,7 +76,7 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
         });
 
       this._consumerApiService.onUserTaskForIdentityFinished(connection.identity,
-        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+        (message: Messages.Public.SystemEvents.UserTaskReachedMessage) => {
 
           const eventToPublish: string = socketSettings.paths.userTaskForIdentityFinished
             .replace(socketSettings.pathParams.userId, connection.userId);
@@ -85,7 +85,7 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
         });
 
       this._consumerApiService.onManualTaskForIdentityWaiting(connection.identity,
-        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+        (message: Messages.Public.SystemEvents.UserTaskReachedMessage) => {
 
           const eventToPublish: string = socketSettings.paths.manualTaskForIdentityWaiting
             .replace(socketSettings.pathParams.userId, connection.userId);
@@ -94,7 +94,7 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
         });
 
       this._consumerApiService.onManualTaskForIdentityFinished(connection.identity,
-        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+        (message: Messages.Public.SystemEvents.UserTaskReachedMessage) => {
 
           const eventToPublish: string = socketSettings.paths.manualTaskForIdentityFinished
             .replace(socketSettings.pathParams.userId, connection.userId);
@@ -105,27 +105,27 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
 
     // Global notifications
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.userTaskReached,
-      (userTaskWaitingMessage: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+      (userTaskWaitingMessage: Messages.Public.SystemEvents.UserTaskReachedMessage) => {
         socketIo.emit(socketSettings.paths.userTaskWaiting, userTaskWaitingMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.userTaskFinished,
-      (userTaskFinishedMessage: Messages.Internal.SystemEvents.UserTaskFinishedMessage) => {
+      (userTaskFinishedMessage: Messages.Public.SystemEvents.UserTaskFinishedMessage) => {
         socketIo.emit(socketSettings.paths.userTaskFinished, userTaskFinishedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.manualTaskReached,
-      (manualTaskWaitingMessage: Messages.Internal.SystemEvents.ManualTaskReachedMessage) => {
+      (manualTaskWaitingMessage: Messages.Public.SystemEvents.ManualTaskReachedMessage) => {
         socketIo.emit(socketSettings.paths.manualTaskWaiting, manualTaskWaitingMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.manualTaskFinished,
-      (manualTaskFinishedMessage: Messages.Internal.SystemEvents.ManualTaskFinishedMessage) => {
+      (manualTaskFinishedMessage: Messages.Public.SystemEvents.ManualTaskFinishedMessage) => {
         socketIo.emit(socketSettings.paths.manualTaskFinished, manualTaskFinishedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processStarted,
-      (processStartedMessage: Messages.Internal.SystemEvents.ProcessStartedMessage) => {
+      (processStartedMessage: Messages.Public.SystemEvents.ProcessStartedMessage) => {
         socketIo.emit(socketSettings.paths.processStarted, processStartedMessage);
 
         const processInstanceStartedIdMessage: string =
@@ -136,12 +136,12 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processEnded,
-      (processEndedMessage: Messages.Internal.BpmnEvents.EndEventReachedMessage) => {
+      (processEndedMessage: Messages.Public.BpmnEvents.EndEventReachedMessage) => {
         socketIo.emit(socketSettings.paths.processEnded, processEndedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processTerminated,
-      (processTerminatedMessage: Messages.Internal.BpmnEvents.TerminateEndEventReachedMessage) => {
+      (processTerminatedMessage: Messages.Public.BpmnEvents.TerminateEndEventReachedMessage) => {
         socketIo.emit(socketSettings.paths.processTerminated, processTerminatedMessage);
       });
   }

--- a/src/consumer_api_socket_endpoint.ts
+++ b/src/consumer_api_socket_endpoint.ts
@@ -1,24 +1,29 @@
+import * as jsonwebtoken from 'jsonwebtoken';
 import {Logger} from 'loggerhythm';
 
 import {UnauthorizedError} from '@essential-projects/errors_ts';
 import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
 import {BaseSocketEndpoint} from '@essential-projects/http_node';
+import {IIdentity, TokenBody} from '@essential-projects/iam_contracts';
 
-import {Messages, socketSettings} from '@process-engine/consumer_api_contracts';
+import {IConsumerApi, Messages, socketSettings} from '@process-engine/consumer_api_contracts';
 
 const logger: Logger = Logger.createLogger('consumer_api:http:socket.io_endpoint');
 
 interface IConnection {
-  identity: string;
+  userId: string;
+  identity: IIdentity;
 }
 
 export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
 
   private _connections: Map<string, IConnection> = new Map();
+  private _consumerApiService: IConsumerApi;
   private _eventAggregator: IEventAggregator;
 
-  constructor(eventAggregator: IEventAggregator) {
+  constructor(consumerApiService: IConsumerApi, eventAggregator: IEventAggregator) {
     super();
+    this._consumerApiService = consumerApiService;
     this._eventAggregator = eventAggregator;
   }
 
@@ -29,16 +34,24 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
   public initializeEndpoint(socketIo: SocketIO.Namespace): void {
 
     socketIo.on('connect', (socket: SocketIO.Socket) => {
-      const identity: string = socket.handshake.headers['authorization'];
+      const token: string = socket.handshake.headers['authorization'];
 
-      const connection: IConnection = {
-        identity: identity,
-      };
-
-      const identityNotSet: boolean = identity === undefined;
+      const identityNotSet: boolean = token === undefined;
       if (identityNotSet) {
         throw new UnauthorizedError('No auth token provided!');
       }
+
+      const identity: IIdentity = {
+        token: token,
+      };
+
+      const decodedIdentity: TokenBody = <TokenBody> jsonwebtoken.decode(identity.token);
+      const userId: string = decodedIdentity.sub;
+
+      const connection: IConnection = {
+        identity: identity,
+        userId: userId,
+      };
 
       this._connections.set(socket.id, connection);
 
@@ -49,30 +62,70 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
 
         logger.info(`Client with socket id "${socket.id} disconnected."`);
       });
+
+      // User specific notifications
+      // We can just pass on the received message, because the ConsumerApiService
+      // will already have ensured that the identites match.
+      this._consumerApiService.onUserTaskForIdentityWaiting(connection.identity,
+        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+
+          const eventToPublish: string = socketSettings.paths.userTaskForIdentityWaiting
+            .replace(socketSettings.pathParams.userId, connection.userId);
+
+          socketIo.emit(eventToPublish, message);
+        });
+
+      this._consumerApiService.onUserTaskForIdentityFinished(connection.identity,
+        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+
+          const eventToPublish: string = socketSettings.paths.userTaskForIdentityFinished
+            .replace(socketSettings.pathParams.userId, connection.userId);
+
+          socketIo.emit(eventToPublish, message);
+        });
+
+      this._consumerApiService.onManualTaskForIdentityWaiting(connection.identity,
+        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+
+          const eventToPublish: string = socketSettings.paths.manualTaskForIdentityWaiting
+            .replace(socketSettings.pathParams.userId, connection.userId);
+
+          socketIo.emit(eventToPublish, message);
+        });
+
+      this._consumerApiService.onManualTaskForIdentityFinished(connection.identity,
+        (message: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
+
+          const eventToPublish: string = socketSettings.paths.manualTaskForIdentityFinished
+            .replace(socketSettings.pathParams.userId, connection.userId);
+
+          socketIo.emit(eventToPublish, message);
+        });
     });
 
+    // Global notifications
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.userTaskReached,
-      (userTaskWaitingMessage: Messages.SystemEvents.UserTaskReachedMessage) => {
+      (userTaskWaitingMessage: Messages.Internal.SystemEvents.UserTaskReachedMessage) => {
         socketIo.emit(socketSettings.paths.userTaskWaiting, userTaskWaitingMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.userTaskFinished,
-      (userTaskFinishedMessage: Messages.SystemEvents.UserTaskFinishedMessage) => {
+      (userTaskFinishedMessage: Messages.Internal.SystemEvents.UserTaskFinishedMessage) => {
         socketIo.emit(socketSettings.paths.userTaskFinished, userTaskFinishedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.manualTaskReached,
-      (manualTaskWaitingMessage: Messages.SystemEvents.ManualTaskReachedMessage) => {
+      (manualTaskWaitingMessage: Messages.Internal.SystemEvents.ManualTaskReachedMessage) => {
         socketIo.emit(socketSettings.paths.manualTaskWaiting, manualTaskWaitingMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.manualTaskFinished,
-      (manualTaskFinishedMessage: Messages.SystemEvents.ManualTaskFinishedMessage) => {
+      (manualTaskFinishedMessage: Messages.Internal.SystemEvents.ManualTaskFinishedMessage) => {
         socketIo.emit(socketSettings.paths.manualTaskFinished, manualTaskFinishedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processStarted,
-      (processStartedMessage: Messages.SystemEvents.ProcessStartedMessage) => {
+      (processStartedMessage: Messages.Internal.SystemEvents.ProcessStartedMessage) => {
         socketIo.emit(socketSettings.paths.processStarted, processStartedMessage);
 
         const processInstanceStartedIdMessage: string =
@@ -83,12 +136,12 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processEnded,
-      (processEndedMessage: Messages.BpmnEvents.EndEventReachedMessage) => {
+      (processEndedMessage: Messages.Internal.BpmnEvents.EndEventReachedMessage) => {
         socketIo.emit(socketSettings.paths.processEnded, processEndedMessage);
       });
 
     this._eventAggregator.subscribe(Messages.EventAggregatorSettings.messagePaths.processTerminated,
-      (processTerminatedMessage: Messages.BpmnEvents.TerminateEndEventReachedMessage) => {
+      (processTerminatedMessage: Messages.Internal.BpmnEvents.TerminateEndEventReachedMessage) => {
         socketIo.emit(socketSettings.paths.processTerminated, processTerminatedMessage);
       });
   }


### PR DESCRIPTION
**Changes:**

1. Use the `IConsumerApiHttpController` interface to ensure a valid HttpController.
2. Add the following UseCases to the router and controller:
    - `getProcessInstancesByIdentity`
    - `getWaitingUserTasksByIdentity`
    - `getWaitingManualTasksByIdentity`
3. Use the `EndEventReachedMessage` and `TerminateEndEventReachedMessage` types in the socket.io controller

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/198

PR: #22

## How can others test the changes?

Use the HttpEndpoint to access the new UseCases. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).