### PR TITLE
✨Additional notifications for activities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "7.0.0-f7e1f918-b14",
+    "@process-engine/consumer_api_contracts": "feature~additional_notifications_for_activities",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "socket.io": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/consumer_api_contracts": "7.0.0-8393af71-b15",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "socket.io": "^2.2.0"

--- a/src/consumer_api_socket_endpoint.ts
+++ b/src/consumer_api_socket_endpoint.ts
@@ -162,8 +162,8 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
     const activityReachedSubscription =
       this.eventAggregator.subscribe(
         Messages.EventAggregatorSettings.messagePaths.activityReached,
-        (activityWaitingMessage: Messages.SystemEvents.ActivityReachedMessage): void => {
-          socketIoInstance.emit(socketSettings.paths.activityReached, activityWaitingMessage);
+        (activityReachedMessage: Messages.SystemEvents.ActivityReachedMessage): void => {
+          socketIoInstance.emit(socketSettings.paths.activityReached, activityReachedMessage);
         },
       );
 

--- a/src/consumer_api_socket_endpoint.ts
+++ b/src/consumer_api_socket_endpoint.ts
@@ -159,19 +159,19 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
         },
       );
 
-    const callActivityReachedSubscription =
+    const activityReachedSubscription =
       this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityReached,
-        (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
-          socketIoInstance.emit(socketSettings.paths.callActivityWaiting, callActivityWaitingMessage);
+        Messages.EventAggregatorSettings.messagePaths.activityReached,
+        (activityWaitingMessage: Messages.SystemEvents.ActivityReachedMessage): void => {
+          socketIoInstance.emit(socketSettings.paths.activityReached, activityWaitingMessage);
         },
       );
 
-    const callActivityFinishedSubscription =
+    const activityFinishedSubscription =
       this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityFinished,
-        (callActivityFinishedMessage: Messages.SystemEvents.CallActivityFinishedMessage): void => {
-          socketIoInstance.emit(socketSettings.paths.callActivityFinished, callActivityFinishedMessage);
+        Messages.EventAggregatorSettings.messagePaths.activityFinished,
+        (activityFinishedMessage: Messages.SystemEvents.ActivityFinishedMessage): void => {
+          socketIoInstance.emit(socketSettings.paths.activityFinished, activityFinishedMessage);
         },
       );
 
@@ -230,8 +230,8 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
       );
 
     this.endpointSubscriptions.push(boundaryEventTriggeredSubscription);
-    this.endpointSubscriptions.push(callActivityReachedSubscription);
-    this.endpointSubscriptions.push(callActivityFinishedSubscription);
+    this.endpointSubscriptions.push(activityReachedSubscription);
+    this.endpointSubscriptions.push(activityFinishedSubscription);
     this.endpointSubscriptions.push(emptyActivityReachedSubscription);
     this.endpointSubscriptions.push(emptyActivityFinishedSubscription);
     this.endpointSubscriptions.push(intermediateThrowEventTriggeredSubscription);

--- a/src/consumer_api_socket_endpoint.ts
+++ b/src/consumer_api_socket_endpoint.ts
@@ -175,6 +175,32 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
         },
       );
 
+    // ---------------------- For backwards compatibility only!
+
+    const callActivityWaitingSubscription =
+      this.eventAggregator.subscribe(
+        Messages.EventAggregatorSettings.messagePaths.callActivityReached,
+        (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
+
+          logger.warn('"callActivityWaiting" notifications are deprecated. Use "activityReached" instead.');
+
+          socketIoInstance.emit(socketSettings.paths.callActivityWaiting, callActivityWaitingMessage);
+        },
+      );
+
+    const callActivityFinishedSubscription =
+      this.eventAggregator.subscribe(
+        Messages.EventAggregatorSettings.messagePaths.callActivityFinished,
+        (callActivityFinishedMessage: Messages.SystemEvents.CallActivityFinishedMessage): void => {
+
+          logger.warn('"callActivityFinished" notifications are deprecated. Use "activityFinished" instead.');
+
+          socketIoInstance.emit(socketSettings.paths.callActivityFinished, callActivityFinishedMessage);
+        },
+      );
+
+    // ----------------------
+
     const manualTaskReachedSubscription =
       this.eventAggregator.subscribe(
         Messages.EventAggregatorSettings.messagePaths.manualTaskReached,
@@ -229,9 +255,11 @@ export class ConsumerApiSocketEndpoint extends BaseSocketEndpoint {
         },
       );
 
-    this.endpointSubscriptions.push(boundaryEventTriggeredSubscription);
     this.endpointSubscriptions.push(activityReachedSubscription);
     this.endpointSubscriptions.push(activityFinishedSubscription);
+    this.endpointSubscriptions.push(boundaryEventTriggeredSubscription);
+    this.endpointSubscriptions.push(callActivityWaitingSubscription);
+    this.endpointSubscriptions.push(callActivityFinishedSubscription);
     this.endpointSubscriptions.push(emptyActivityReachedSubscription);
     this.endpointSubscriptions.push(emptyActivityFinishedSubscription);
     this.endpointSubscriptions.push(intermediateThrowEventTriggeredSubscription);


### PR DESCRIPTION
## Changes

1. Refactor notification subscriptions `onCallActivityWaiting` to `onActivityReached` and `onCallActivityFinished` to `onActivityFinished`.
2. Generalize activity subscription paths, messages and types.
    - This will allow the user to susbcribe to notifications about more than just CallActivities, but also ScriptTasks, SendTasks, ReceiveTasks, ServiceTasks and Subprocesses.
3. Mark `onCallActivityWaiting` and `onCallActivityFinished` as deprecated.
    - The notifications will be removed with the next major release, to give people time to properly adjust their usage of the notifications.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/349

PR: #32

## How to test the changes

- Create Subscriptions for `onActivityReached` and `onActivityFinished`
- The corresponding callbacks will be triggered, when any kind of activity is reached or finished

