### PR TITLE
✨Import ExternalTaskApi

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -2,6 +2,7 @@
 
 const EmptyActivityEndpoint = require('./dist/commonjs/index').Endpoints.EmptyActivity;
 const EventEndpoint = require('./dist/commonjs/index').Endpoints.Event;
+const ExternalTaskEndpoint = require('./dist/commonjs/index').Endpoints.ExternalTask;
 const ManualTaskEndpoint = require('./dist/commonjs/index').Endpoints.ManualTask;
 const NotificationEndpoint = require('./dist/commonjs/index').Endpoints.Notification;
 const ProcessModelEndpoint = require('./dist/commonjs/index').Endpoints.ProcessModel;
@@ -13,6 +14,7 @@ const socketEndpointDiscoveryTag = require('@essential-projects/bootstrapper_con
 function registerInContainer(container) {
   registerHttpEndpoints(container);
   registerSocketEndpoints(container);
+  registerDeprecatedEndpoints(container);
 }
 
 function registerHttpEndpoints(container) {
@@ -33,6 +35,15 @@ function registerHttpEndpoints(container) {
 
   container.register('ConsumerApiEventController', EventEndpoint.EventController)
     .dependencies('ConsumerApiEventService')
+    .singleton();
+
+  container.register('ConsumerApiExternalTaskRouter', ExternalTaskEndpoint.ExternalTaskRouter)
+    .dependencies('ConsumerApiExternalTaskController', 'IdentityService')
+    .singleton()
+    .tags(routerDiscoveryTag);
+
+  container.register('ConsumerApiExternalTaskController', ExternalTaskEndpoint.ExternalTaskController)
+    .dependencies('ConsumerApiExternalTaskService')
     .singleton();
 
   container.register('ConsumerApiManualTaskRouter', ManualTaskEndpoint.ManualTaskRouter)
@@ -69,6 +80,14 @@ function registerSocketEndpoints(container) {
     .dependencies('EventAggregator', 'IdentityService', 'ConsumerApiNotificationService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
+}
+
+function registerDeprecatedEndpoints(container) {
+
+  container.register('ConsumerApiExternalTaskRouterDeprecated', ExternalTaskEndpoint.ExternalTaskRouterDeprecated)
+    .dependencies('ConsumerApiExternalTaskController', 'IdentityService')
+    .singleton()
+    .tags(routerDiscoveryTag);
 }
 
 module.exports.registerInContainer = registerInContainer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/consumer_api_contracts": {
-      "version": "8.0.0-dad26234-b24",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-dad26234-b24.tgz",
-      "integrity": "sha512-yM1yWz6e5KCWpuQLq9yNMeOWhWTNNxbP7vuZonk5aE3bgFC9hEWmp+vAlArhn4XXrn67i6xayfVQJ4AP1XqT6w==",
+      "version": "8.0.0-94a2de90-b5",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-94a2de90-b5.tgz",
+      "integrity": "sha512-VeTCJxo9ombWoVkRk4u/2Mhc2tz8E2NTh1GlDPPOEgZYs9jUyHMVZaVTHf79e146zdD73n6BQbbSi9ZJURFQCw==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -93,7 +93,19 @@
         "@types/express": "^4.16.0",
         "@types/node": "^10.12.2",
         "@types/socket.io": "^2.1.0",
-        "@types/socket.io-client": "^1.4.32"
+        "@types/socket.io-client": "^1.4.32",
+        "moment": "^2.24.0"
+      }
+    },
+    "@process-engine/external_task_api_contracts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@process-engine/external_task_api_contracts/-/external_task_api_contracts-1.1.0.tgz",
+      "integrity": "sha512-znCntpqftSgqLYuDfQfCQ5BB7l8eqLYEv4gWfBNqjDaCT69zg1MknBwUbo8JbvEHDCSiHSG1VWxq9ASwIAO01A==",
+      "requires": {
+        "@essential-projects/iam_contracts": "^3.4.0",
+        "@types/express": "^4.16.0",
+        "@types/node": "^10.12.2",
+        "moment": "~2.24.0"
       }
     },
     "@types/body-parser": {
@@ -106,9 +118,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -121,9 +133,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -153,9 +165,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -198,9 +210,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.6.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-          "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+          "version": "12.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
+          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
         }
       }
     },
@@ -361,9 +373,9 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-middleware": {
       "version": "1.2.1",
@@ -1211,9 +1223,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
       "dev": true
     },
     "has": {
@@ -1257,10 +1269,13 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -1513,6 +1528,15 @@
         "chalk": "^2.1.0"
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -1588,6 +1612,11 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.0.0",
@@ -2380,9 +2409,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
-      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -2498,6 +2527,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     },
     "yeast": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@process-engine/consumer_api_contracts": {
-      "version": "8.0.0-94a2de90-b5",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-94a2de90-b5.tgz",
-      "integrity": "sha512-VeTCJxo9ombWoVkRk4u/2Mhc2tz8E2NTh1GlDPPOEgZYs9jUyHMVZaVTHf79e146zdD73n6BQbbSi9ZJURFQCw==",
+      "version": "8.0.0-178f6ae9-b25",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-8.0.0-178f6ae9-b25.tgz",
+      "integrity": "sha512-030dmkzkrwWcXp2RAX5GkLkPJqmone8CVJVwG8A1JDExlCKdOur7IeuMdf6/RoL3d5fUQRjAK9k09w6Au0tcMg==",
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -118,9 +118,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },
@@ -133,9 +133,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },
@@ -165,9 +165,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },
@@ -183,9 +183,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "10.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
-      "integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ=="
+      "version": "10.14.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.15.tgz",
+      "integrity": "sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -210,9 +210,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.0.tgz",
-          "integrity": "sha512-vqcj1MVm2Sla4PpMfYKh1MyDN4D2f/mPIZD7RdAGqEsbE+JxfeqQHHVbRDQ0Nqn8i73gJa1HQ1Pu3+nH4Q0Yiw=="
+          "version": "12.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+          "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "8.0.0-dad26234-b24",
+    "@process-engine/consumer_api_contracts": "feature~import_external_task_api",
+    "@process-engine/external_task_api_contracts": "^1.1.0",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "socket.io": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~import_external_task_api",
+    "@process-engine/consumer_api_contracts": "8.0.0-178f6ae9-b25",
     "@process-engine/external_task_api_contracts": "^1.1.0",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",

--- a/src/endpoints/external_task/external_task_controller.ts
+++ b/src/endpoints/external_task/external_task_controller.ts
@@ -1,0 +1,84 @@
+import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
+
+import {APIs} from '@process-engine/consumer_api_contracts';
+
+import {Response} from 'express';
+
+export class ExternalTaskController {
+
+  private httpCodeSuccessfulResponse = 200;
+  private httpCodeSuccessfulNoContentResponse = 204;
+
+  private externalTaskService: APIs.IExternalTaskConsumerApi;
+
+  constructor(externalTaskService: APIs.IExternalTaskConsumerApi) {
+    this.externalTaskService = externalTaskService;
+  }
+
+  public async fetchAndLockExternalTasks(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+
+    const identity = request.identity;
+
+    const payload = request.body;
+
+    const result = await this.externalTaskService.fetchAndLockExternalTasks(
+      identity,
+      payload.workerId,
+      payload.topicName,
+      payload.maxTasks,
+      payload.longPollingTimeout,
+      payload.lockDuration,
+    );
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async extendLock(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+
+    const externalTaskId = request.params.external_task_id;
+    const identity = request.identity;
+
+    const payload = request.body;
+
+    await this.externalTaskService.extendLock(identity, payload.workerId, externalTaskId, payload.additionalDuration);
+
+    response.status(this.httpCodeSuccessfulNoContentResponse).send();
+  }
+
+  public async handleBpmnError(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+
+    const externalTaskId = request.params.external_task_id;
+    const identity = request.identity;
+
+    const payload = request.body;
+
+    await this.externalTaskService.handleBpmnError(identity, payload.workerId, externalTaskId, payload.errorCode);
+
+    response.status(this.httpCodeSuccessfulNoContentResponse).send();
+  }
+
+  public async handleServiceError(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+
+    const externalTaskId = request.params.external_task_id;
+    const identity = request.identity;
+
+    const payload = request.body;
+
+    await this.externalTaskService.handleServiceError(identity, payload.workerId, externalTaskId, payload.errorMessage, payload.errorDetails);
+
+    response.status(this.httpCodeSuccessfulNoContentResponse).send();
+  }
+
+  public async finishExternalTask(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+
+    const externalTaskId = request.params.external_task_id;
+    const identity = request.identity;
+
+    const payload = request.body;
+
+    await this.externalTaskService.finishExternalTask(identity, payload.workerId, externalTaskId, payload.result);
+
+    response.status(this.httpCodeSuccessfulNoContentResponse).send();
+  }
+
+}

--- a/src/endpoints/external_task/external_task_controller.ts
+++ b/src/endpoints/external_task/external_task_controller.ts
@@ -1,10 +1,10 @@
 import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
 
-import {APIs} from '@process-engine/consumer_api_contracts';
+import {APIs, HttpController} from '@process-engine/consumer_api_contracts';
 
 import {Response} from 'express';
 
-export class ExternalTaskController {
+export class ExternalTaskController implements HttpController.IExternalTaskHttpController {
 
   private httpCodeSuccessfulResponse = 200;
   private httpCodeSuccessfulNoContentResponse = 204;

--- a/src/endpoints/external_task/external_task_router.ts
+++ b/src/endpoints/external_task/external_task_router.ts
@@ -1,0 +1,43 @@
+import {wrap} from 'async-middleware';
+
+import {BaseRouter} from '@essential-projects/http_node';
+import {IIdentityService} from '@essential-projects/iam_contracts';
+
+import {restSettings} from '@process-engine/consumer_api_contracts';
+
+import {ExternalTaskController} from './external_task_controller';
+import {createResolveIdentityMiddleware} from '../../middlewares/index';
+
+export class ExternalTaskRouter extends BaseRouter {
+
+  private externalTaskController: ExternalTaskController;
+  private identityService: IIdentityService;
+
+  constructor(externalTaskController: ExternalTaskController, identityService: IIdentityService) {
+    super();
+    this.externalTaskController = externalTaskController;
+    this.identityService = identityService;
+  }
+
+  public get baseRoute(): string {
+    return 'api/consumer/v1';
+  }
+
+  public async initializeRouter(): Promise<void> {
+    this.registerMiddlewares();
+
+    const controller = this.externalTaskController;
+
+    this.router.post(restSettings.paths.fetchAndLockExternalTasks, wrap(controller.fetchAndLockExternalTasks.bind(controller)));
+    this.router.post(restSettings.paths.extendExternalTaskLock, wrap(controller.extendLock.bind(controller)));
+    this.router.post(restSettings.paths.finishExternalTaskWithBpmnError, wrap(controller.handleBpmnError.bind(controller)));
+    this.router.post(restSettings.paths.finishExternalTaskWithServiceError, wrap(controller.handleServiceError.bind(controller)));
+    this.router.post(restSettings.paths.finishExternalTask, wrap(controller.finishExternalTask.bind(controller)));
+  }
+
+  private registerMiddlewares(): void {
+    const resolveIdentity = createResolveIdentityMiddleware(this.identityService);
+    this.router.use(wrap(resolveIdentity));
+  }
+
+}

--- a/src/endpoints/external_task/external_task_router_deprecated.ts
+++ b/src/endpoints/external_task/external_task_router_deprecated.ts
@@ -1,0 +1,48 @@
+import {wrap} from 'async-middleware';
+
+import {BaseRouter} from '@essential-projects/http_node';
+import {IIdentityService} from '@essential-projects/iam_contracts';
+
+import {restSettings} from '@process-engine/external_task_api_contracts';
+
+import {ExternalTaskController} from './external_task_controller';
+import {createResolveIdentityMiddleware} from '../../middlewares/index';
+
+/**
+ * This router provides the old endpoints for the ExternalTaskAPI.
+ * Those routes will be removed in future versions, after users had time
+ * to adjust their usage of ExternalTasks.
+ */
+export class ExternalTaskRouterDeprecated extends BaseRouter {
+
+  private externalTaskController: ExternalTaskController;
+  private identityService: IIdentityService;
+
+  constructor(externalTaskController: ExternalTaskController, identityService: IIdentityService) {
+    super();
+    this.externalTaskController = externalTaskController;
+    this.identityService = identityService;
+  }
+
+  public get baseRoute(): string {
+    return 'api/external_task/v1';
+  }
+
+  public async initializeRouter(): Promise<void> {
+    this.registerMiddlewares();
+
+    const controller = this.externalTaskController;
+
+    this.router.post(restSettings.paths.fetchAndLockExternalTasks, wrap(controller.fetchAndLockExternalTasks.bind(controller)));
+    this.router.post(restSettings.paths.extendLock, wrap(controller.extendLock.bind(controller)));
+    this.router.post(restSettings.paths.handleBpmnError, wrap(controller.handleBpmnError.bind(controller)));
+    this.router.post(restSettings.paths.handleServiceError, wrap(controller.handleServiceError.bind(controller)));
+    this.router.post(restSettings.paths.finishExternalTask, wrap(controller.finishExternalTask.bind(controller)));
+  }
+
+  private registerMiddlewares(): void {
+    const resolveIdentity = createResolveIdentityMiddleware(this.identityService);
+    this.router.use(wrap(resolveIdentity));
+  }
+
+}

--- a/src/endpoints/external_task/index.ts
+++ b/src/endpoints/external_task/index.ts
@@ -1,0 +1,3 @@
+export * from './external_task_controller';
+export * from './external_task_router_deprecated';
+export * from './external_task_router';

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as EmptyActivityEndpoint from './empty_activity/index';
 import * as EventEndpoint from './events/index';
+import * as ExternalTaskEndpoint from './external_task/index';
 import * as ManualTaskEndpoint from './manual_task/index';
 import * as NotificationEndpoint from './notifications/index';
 import * as ProcessModelEndpoint from './process_model/index';
@@ -9,6 +10,7 @@ import * as UserTaskEndpoint from './user_task/index';
 export namespace Endpoints {
   export import EmptyActivity = EmptyActivityEndpoint;
   export import Event = EventEndpoint;
+  export import ExternalTask = ExternalTaskEndpoint;
   export import ManualTask = ManualTaskEndpoint;
   export import Notification = NotificationEndpoint;
   export import ProcessModel = ProcessModelEndpoint;


### PR DESCRIPTION
## Changes

1. Import the old endpoints for ExternalTaskManagement (marked as deprecated)
    - This will guarantee that the current ExternalTaskApi clients can still access the ProcessEngine, after the ExternalTask modules have been removed.
2. Add new imports for handling ExternalTasks (with a `api/consumer/v1` prefix)

## Issues

PR: #36
