### PR TITLE
🔒 Throw error, if an Authorization header contains multiple tokens

### DIFF
--- a/src/middlewares/resolve_identity.ts
+++ b/src/middlewares/resolve_identity.ts
@@ -1,8 +1,11 @@
 import {NextFunction, Response} from 'express';
+import {Logger} from 'loggerhythm';
 
-import {UnauthorizedError} from '@essential-projects/errors_ts';
+import {BadRequestError, UnauthorizedError} from '@essential-projects/errors_ts';
 import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
 import {IIdentityService} from '@essential-projects/iam_contracts';
+
+const logger = Logger.createLogger('processengine:consumer_api:resolve_identity_middleware');
 
 export type MiddlewareFunction = (request: HttpRequestWithIdentity, response: Response, next: NextFunction) => Promise<void>;
 
@@ -13,6 +16,14 @@ export function createResolveIdentityMiddleware(identityService: IIdentityServic
 
     if (!bearerToken) {
       throw new UnauthorizedError('No auth token provided!');
+    }
+
+    // Multiple authorization header values are not supported. So throw an error, if this happens.
+    // Background: https://github.com/process-engine/process_engine_runtime/issues/396
+    const splitHeaderValues = bearerToken.split(',');
+    if (splitHeaderValues.length > 1) {
+      logger.error('Detected multiple values for the authorization header!', splitHeaderValues);
+      throw new BadRequestError('Detected multiple values for the authorization header!');
     }
 
     const authToken = bearerToken.substr('Bearer '.length);


### PR DESCRIPTION
## Changes

Add a check to the `resolveIdentity` middleware, which will verify a request's Auth-header.
If the header contains multiple tokens, an error is thrown, since this is not supported.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/396

PR: #51

## How to test the changes

Make requests against the endpoint, which contain authorization headers with multiple tokens and see what happens.