### PR TITLE
 🔥 Remove CallActivity notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "8.1.0-9b902a18-b33",
+    "@process-engine/consumer_api_contracts": "feature~remove_on_call_activity_waiting_notification",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "socket.io": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~remove_on_call_activity_waiting_notification",
+    "@process-engine/consumer_api_contracts": "9.0.0-328ece37-b34",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "socket.io": "^2.2.0"

--- a/src/endpoints/notifications/notification_endpoints.ts
+++ b/src/endpoints/notifications/notification_endpoints.ts
@@ -175,32 +175,6 @@ export class NotificationSocketEndpoint extends BaseSocketEndpoint {
         },
       );
 
-    // ---------------------- For backwards compatibility only!
-
-    const callActivityWaitingSubscription =
-      this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityReached,
-        (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
-
-          logger.warn('"callActivityWaiting" notifications are deprecated. Use "activityReached" instead.');
-
-          socketIoInstance.emit(socketSettings.paths.callActivityWaiting, callActivityWaitingMessage);
-        },
-      );
-
-    const callActivityFinishedSubscription =
-      this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityFinished,
-        (callActivityFinishedMessage: Messages.SystemEvents.CallActivityFinishedMessage): void => {
-
-          logger.warn('"callActivityFinished" notifications are deprecated. Use "activityFinished" instead.');
-
-          socketIoInstance.emit(socketSettings.paths.callActivityFinished, callActivityFinishedMessage);
-        },
-      );
-
-    // ----------------------
-
     const manualTaskReachedSubscription =
       this.eventAggregator.subscribe(
         Messages.EventAggregatorSettings.messagePaths.manualTaskReached,
@@ -258,8 +232,6 @@ export class NotificationSocketEndpoint extends BaseSocketEndpoint {
     this.endpointSubscriptions.push(activityReachedSubscription);
     this.endpointSubscriptions.push(activityFinishedSubscription);
     this.endpointSubscriptions.push(boundaryEventTriggeredSubscription);
-    this.endpointSubscriptions.push(callActivityWaitingSubscription);
-    this.endpointSubscriptions.push(callActivityFinishedSubscription);
     this.endpointSubscriptions.push(emptyActivityReachedSubscription);
     this.endpointSubscriptions.push(emptyActivityFinishedSubscription);
     this.endpointSubscriptions.push(intermediateThrowEventTriggeredSubscription);


### PR DESCRIPTION
## Changes

1. Remove all the deprecated `CallActivity` notifications

## Issues

PR: #40