### PR TITLE
🐛 Fix handling of customized ExternalTaskErrors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_http",
-  "version": "5.2.0-alpha.1",
+  "version": "5.3.0",
   "description": "the http-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~add_optional_message_to_bpmn_error_type",
+    "@process-engine/consumer_api_contracts": "9.2.0-alpha.1",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "openapi-doc": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "^9.1.0",
+    "@process-engine/consumer_api_contracts": "feature~add_optional_message_to_bpmn_error_type",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "openapi-doc": "^4.1.6",

--- a/src/endpoints/external_task/external_task_controller.ts
+++ b/src/endpoints/external_task/external_task_controller.ts
@@ -52,7 +52,7 @@ export class ExternalTaskController implements HttpController.IExternalTaskHttpC
 
     const payload = request.body;
 
-    await this.externalTaskService.handleBpmnError(identity, payload.workerId, externalTaskId, payload.errorCode);
+    await this.externalTaskService.handleBpmnError(identity, payload.workerId, externalTaskId, payload.errorCode, payload.errorMessage);
 
     response.status(this.httpCodeSuccessfulNoContentResponse).send();
   }
@@ -64,7 +64,9 @@ export class ExternalTaskController implements HttpController.IExternalTaskHttpC
 
     const payload = request.body;
 
-    await this.externalTaskService.handleServiceError(identity, payload.workerId, externalTaskId, payload.errorMessage, payload.errorDetails);
+    await this
+      .externalTaskService
+      .handleServiceError(identity, payload.workerId, externalTaskId, payload.errorMessage, payload.errorDetails, payload.errorCode);
 
     response.status(this.httpCodeSuccessfulNoContentResponse).send();
   }


### PR DESCRIPTION
## Changes

1. Account for `errorMessage` and `errorCode` properties in ExternalTask requests

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/493

PR: #43

## How to test the changes

- Run a Process that uses ExternalTasks with ErrorBoundaryEvents
- Provoke an error that can be intercepted by the BoundaryEvent
- See that it works