### PR TITLE
✨ Add route for retrieving informtion about the host application

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,3 +1,4 @@
+const ApplicationInfoEndpoint = require('./dist/commonjs/index').Endpoints.ApplicationInfo;
 const EmptyActivityEndpoint = require('./dist/commonjs/index').Endpoints.EmptyActivity;
 const EventEndpoint = require('./dist/commonjs/index').Endpoints.Event;
 const ExternalTaskEndpoint = require('./dist/commonjs/index').Endpoints.ExternalTask;
@@ -18,6 +19,15 @@ function registerInContainer(container) {
 }
 
 function registerHttpEndpoints(container) {
+
+  container.register('ConsumerApiApplicationInfoRouter', ApplicationInfoEndpoint.ApplicationInfoRouter)
+    .dependencies('ConsumerApiApplicationInfoController')
+    .singleton()
+    .tags(routerDiscoveryTag);
+
+  container.register('ConsumerApiApplicationInfoController', ApplicationInfoEndpoint.ApplicationInfoController)
+    .dependencies('ConsumerApiApplicationInfoService')
+    .singleton();
 
   container.register('ConsumerApiEmptyActivityRouter', EmptyActivityEndpoint.EmptyActivityRouter)
     .dependencies('ConsumerApiEmptyActivityController', 'IdentityService')

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "^9.2.0",
+    "@process-engine/consumer_api_contracts": "feature~add_info_route",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "openapi-doc": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/consumer_api_contracts": "feature~add_info_route",
+    "@process-engine/consumer_api_contracts": "10.0.0-alpha.2",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "openapi-doc": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_http",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "the http-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/endpoints/application_info/application_info_controller.ts
+++ b/src/endpoints/application_info/application_info_controller.ts
@@ -15,7 +15,8 @@ export class ApplicationInfoController implements HttpController.IApplicationInf
   }
 
   public async getApplicationInfo(request: HttpRequestWithIdentity, response: Response): Promise<void> {
-    const result = await this.applicationInfoService.getApplicationInfo();
+    const identity = request.identity;
+    const result = await this.applicationInfoService.getApplicationInfo(identity);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/endpoints/application_info/application_info_controller.ts
+++ b/src/endpoints/application_info/application_info_controller.ts
@@ -1,0 +1,23 @@
+import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
+
+import {APIs, HttpController} from '@process-engine/consumer_api_contracts';
+
+import {Response} from 'express';
+
+export class ApplicationInfoController implements HttpController.IApplicationInfoHttpController {
+
+  private httpCodeSuccessfulResponse = 200;
+
+  private applicationInfoService: APIs.IApplicationInfoConsumerApi;
+
+  constructor(applicationInfoService: APIs.IApplicationInfoConsumerApi) {
+    this.applicationInfoService = applicationInfoService;
+  }
+
+  public async getApplicationInfo(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const result = await this.applicationInfoService.getApplicationInfo();
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+}

--- a/src/endpoints/application_info/application_info_router.ts
+++ b/src/endpoints/application_info/application_info_router.ts
@@ -1,0 +1,32 @@
+import {wrap} from 'async-middleware';
+
+import {BaseRouter} from '@essential-projects/http_node';
+
+import {restSettings} from '@process-engine/consumer_api_contracts';
+
+import {ApplicationInfoController} from './application_info_controller';
+
+export class ApplicationInfoRouter extends BaseRouter {
+
+  private applicationInfoController: ApplicationInfoController;
+
+  constructor(applicationInfoController: ApplicationInfoController) {
+    super();
+    this.applicationInfoController = applicationInfoController;
+  }
+
+  public get baseRoute(): string {
+    return 'api/consumer/v1';
+  }
+
+  public async initializeRouter(): Promise<void> {
+    this.registerRoutes();
+  }
+
+  private registerRoutes(): void {
+    const controller = this.applicationInfoController;
+
+    this.router.get(restSettings.paths.getApplicationInfo, wrap(controller.getApplicationInfo.bind(controller)));
+  }
+
+}

--- a/src/endpoints/application_info/application_info_router.ts
+++ b/src/endpoints/application_info/application_info_router.ts
@@ -1,5 +1,7 @@
 import {wrap} from 'async-middleware';
+import {NextFunction, Request, Response} from 'express';
 
+import {BaseError} from '@essential-projects/errors_ts';
 import {BaseRouter} from '@essential-projects/http_node';
 
 import {restSettings} from '@process-engine/consumer_api_contracts';
@@ -26,7 +28,20 @@ export class ApplicationInfoRouter extends BaseRouter {
   private registerRoutes(): void {
     const controller = this.applicationInfoController;
 
-    this.router.get(restSettings.paths.getApplicationInfo, wrap(controller.getApplicationInfo.bind(controller)));
+    this.router.get(restSettings.paths.getApplicationInfo, errorHandler, wrap(controller.getApplicationInfo.bind(controller)));
   }
 
+}
+
+// TODO:
+// There is a bug with either the HTTP extension, express, or the BaseRouter, which causes the "resolveIdentity" middleware to be applied to
+// ALL of the consumer api routers, even if they do not make explicit use of that middleware.
+// Since this route is designed to be used without the need of any identity, we need to intercept the 401 errors here
+// that the middleware throws, if no auth token is provided.
+function errorHandler(error: BaseError, request: Request, response: Response, next: NextFunction): void {
+  if (error.code === 401) {
+    next();
+  } else {
+    next(error);
+  }
 }

--- a/src/endpoints/application_info/application_info_router.ts
+++ b/src/endpoints/application_info/application_info_router.ts
@@ -1,7 +1,5 @@
 import {wrap} from 'async-middleware';
-import {NextFunction, Request, Response} from 'express';
 
-import {BaseError} from '@essential-projects/errors_ts';
 import {BaseRouter} from '@essential-projects/http_node';
 
 import {restSettings} from '@process-engine/consumer_api_contracts';
@@ -28,20 +26,7 @@ export class ApplicationInfoRouter extends BaseRouter {
   private registerRoutes(): void {
     const controller = this.applicationInfoController;
 
-    this.router.get(restSettings.paths.getApplicationInfo, errorHandler, wrap(controller.getApplicationInfo.bind(controller)));
+    this.router.get(restSettings.paths.getApplicationInfo, wrap(controller.getApplicationInfo.bind(controller)));
   }
 
-}
-
-// TODO:
-// There is a bug with either the HTTP extension, express, or the BaseRouter, which causes the "resolveIdentity" middleware to be applied to
-// ALL of the consumer api routers, even if they do not make explicit use of that middleware.
-// Since this route is designed to be used without the need of any identity, we need to intercept the 401 errors here
-// that the middleware throws, if no auth token is provided.
-function errorHandler(error: BaseError, request: Request, response: Response, next: NextFunction): void {
-  if (error.code === 401) {
-    next();
-  } else {
-    next(error);
-  }
 }

--- a/src/endpoints/application_info/index.ts
+++ b/src/endpoints/application_info/index.ts
@@ -1,0 +1,2 @@
+export * from './application_info_controller';
+export * from './application_info_router';

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import * as ApplicationInfoEndpoint from './application_info/index';
 import * as EmptyActivityEndpoint from './empty_activity/index';
 import * as EventEndpoint from './events/index';
 import * as ExternalTaskEndpoint from './external_task/index';
@@ -10,6 +11,7 @@ import * as FlowNodeInstanceEndpoint from './flow_node_instance/index';
 import * as SwaggerEndpoint from './swagger/index';
 
 export namespace Endpoints {
+  export import ApplicationInfo = ApplicationInfoEndpoint;
   export import EmptyActivity = EmptyActivityEndpoint;
   export import Event = EventEndpoint;
   export import ExternalTask = ExternalTaskEndpoint;


### PR DESCRIPTION
## Changes

Implement `getApplicationInfo` endpoint.

This endpoint does not require authentication. You can use it without providing an identity.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/531

PR: #44

## How to test the changes

- Call the endpoint
- See that it returns information about the hosting application