### PR TITLE
♻️ Mark api/external_task/v1 routes as deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/consumer_api_http",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "the http-package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/bootstrapper_contracts": "^1.4.0",
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/event_aggregator_contracts": "^4.1.0",
-    "@essential-projects/http_contracts": "^2.4.0",
+    "@essential-projects/http_contracts": "feature~add_deprecation_warning_middleware",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
     "@process-engine/consumer_api_contracts": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@essential-projects/bootstrapper_contracts": "^1.4.0",
     "@essential-projects/errors_ts": "^1.5.0",
     "@essential-projects/event_aggregator_contracts": "^4.1.0",
-    "@essential-projects/http_contracts": "feature~add_deprecation_warning_middleware",
+    "@essential-projects/http_contracts": "^2.6.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
     "@process-engine/consumer_api_contracts": "^10.0.0",

--- a/src/endpoints/external_task/external_task_router_deprecated.ts
+++ b/src/endpoints/external_task/external_task_router_deprecated.ts
@@ -1,5 +1,6 @@
 import {wrap} from 'async-middleware';
 
+import {deprecate} from '@essential-projects/http_contracts';
 import {BaseRouter} from '@essential-projects/http_node';
 import {IIdentityService} from '@essential-projects/iam_contracts';
 
@@ -33,11 +34,31 @@ export class ExternalTaskRouterDeprecated extends BaseRouter {
 
     const controller = this.externalTaskController;
 
-    this.router.post(restSettings.paths.fetchAndLockExternalTasks, wrap(controller.fetchAndLockExternalTasks.bind(controller)));
-    this.router.post(restSettings.paths.extendExternalTaskLock, wrap(controller.extendLock.bind(controller)));
-    this.router.post(restSettings.paths.finishExternalTaskWithBpmnError, wrap(controller.handleBpmnError.bind(controller)));
-    this.router.post(restSettings.paths.finishExternalTaskWithServiceError, wrap(controller.handleServiceError.bind(controller)));
-    this.router.post(restSettings.paths.finishExternalTask, wrap(controller.finishExternalTask.bind(controller)));
+    this.router.post(
+      restSettings.paths.fetchAndLockExternalTasks,
+      deprecate(`api/consumer/v1${restSettings.paths.fetchAndLockExternalTasks}`),
+      wrap(controller.fetchAndLockExternalTasks.bind(controller)),
+    );
+    this.router.post(
+      restSettings.paths.extendExternalTaskLock,
+      deprecate(`api/consumer/v1${restSettings.paths.extendExternalTaskLock}`),
+      wrap(controller.extendLock.bind(controller)),
+    );
+    this.router.post(
+      restSettings.paths.finishExternalTaskWithBpmnError,
+      deprecate(`api/consumer/v1${restSettings.paths.finishExternalTaskWithBpmnError}`),
+      wrap(controller.handleBpmnError.bind(controller)),
+    );
+    this.router.post(
+      restSettings.paths.finishExternalTaskWithServiceError,
+      deprecate(`api/consumer/v1${restSettings.paths.finishExternalTaskWithServiceError}`),
+      wrap(controller.handleServiceError.bind(controller)),
+    );
+    this.router.post(
+      restSettings.paths.finishExternalTask,
+      deprecate(`api/consumer/v1${restSettings.paths.finishExternalTaskWithServiceError}`),
+      wrap(controller.finishExternalTask.bind(controller)),
+    );
   }
 
   private registerMiddlewares(): void {


### PR DESCRIPTION
## Changes

Add `depcreated` warning to all obsolete `api/external_task/v1` routes.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/533

PR: #45

## How to test the changes

- Try accessing any of the old `api/external_task/v1`
- See that you'll get a deprecation warning printed to the console
- Also notice that the response headers will contain values for `Deprecated` and `Link`

Example:

![Bildschirmfoto 2020-03-11 um 11 30 21](https://user-images.githubusercontent.com/15343316/76407495-b797bc00-638b-11ea-97d1-d4cfc15e75a0.png)
